### PR TITLE
Squashed commit of the following:

### DIFF
--- a/LoopFollow.xcodeproj/project.pbxproj
+++ b/LoopFollow.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		DDC7E5472DBD8A1600EB1127 /* AlarmEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC7E5402DBD8A1600EB1127 /* AlarmEditor.swift */; };
 		DDC7E5CF2DC77C2000EB1127 /* SnoozerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC7E5CE2DC77C2000EB1127 /* SnoozerViewModel.swift */; };
 		DDCC3A4B2DDBB5E4006F1C10 /* BatteryCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC3A4A2DDBB5E4006F1C10 /* BatteryCondition.swift */; };
+		DDCC3A502DDED000006F1C10 /* PumpBatteryCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC3A512DDED000006F1C10 /* PumpBatteryCondition.swift */; };
 		DDCC3A4D2DDBB77C006F1C10 /* BatteryAlarmEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC3A4C2DDBB77C006F1C10 /* BatteryAlarmEditor.swift */; };
 		DDCC3A4F2DDC5B54006F1C10 /* BatteryDropCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC3A4E2DDC5B54006F1C10 /* BatteryDropCondition.swift */; };
 		DDCC3A542DDC5D62006F1C10 /* BatteryDropAlarmEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC3A532DDC5D62006F1C10 /* BatteryDropAlarmEditor.swift */; };
@@ -597,6 +598,7 @@
 		DDC7E5402DBD8A1600EB1127 /* AlarmEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmEditor.swift; sourceTree = "<group>"; };
 		DDC7E5CE2DC77C2000EB1127 /* SnoozerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnoozerViewModel.swift; sourceTree = "<group>"; };
 		DDCC3A4A2DDBB5E4006F1C10 /* BatteryCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryCondition.swift; sourceTree = "<group>"; };
+		DDCC3A512DDED000006F1C10 /* PumpBatteryCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpBatteryCondition.swift; sourceTree = "<group>"; };
 		DDCC3A4C2DDBB77C006F1C10 /* BatteryAlarmEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryAlarmEditor.swift; sourceTree = "<group>"; };
 		DDCC3A4E2DDC5B54006F1C10 /* BatteryDropCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryDropCondition.swift; sourceTree = "<group>"; };
 		DDCC3A532DDC5D62006F1C10 /* BatteryDropAlarmEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryDropAlarmEditor.swift; sourceTree = "<group>"; };
@@ -886,6 +888,7 @@
 				DDCC3A552DDC9617006F1C10 /* MissedBolusCondition.swift */,
 				DDCC3A4E2DDC5B54006F1C10 /* BatteryDropCondition.swift */,
 				DDCC3A4A2DDBB5E4006F1C10 /* BatteryCondition.swift */,
+				DDCC3A512DDED000006F1C10 /* PumpBatteryCondition.swift */,
 				DDB9FC7A2DDB573F00EFAA76 /* IOBCondition.swift */,
 				DDC6CA482DD8E47A0060EE25 /* PumpVolumeCondition.swift */,
 				DDC6CA442DD8D8E60060EE25 /* PumpChangeCondition.swift */,
@@ -1949,6 +1952,7 @@
 				DDC7E5152DBCFA7900EB1127 /* SnoozerViewController.swift in Sources */,
 				DD7F4C072DD5042F00D449E9 /* OverrideStartAlarmEditor.swift in Sources */,
 				DDCC3A4B2DDBB5E4006F1C10 /* BatteryCondition.swift in Sources */,
+				DDCC3A502DDED000006F1C10 /* PumpBatteryCondition.swift in Sources */,
 				DDDF6F492D479AF000884336 /* NoRemoteView.swift in Sources */,
 				656F8C142E49F3D20008DC1D /* RemoteCommandSettings.swift in Sources */,
 				DD12D4872E1705E6004E0112 /* AlarmsContainerView.swift in Sources */,

--- a/LoopFollow/Alarm/Alarm.swift
+++ b/LoopFollow/Alarm/Alarm.swift
@@ -318,6 +318,9 @@ struct Alarm: Identifiable, Codable, Equatable {
         case .pump:
             soundFile = .marimbaDescend
             threshold = 20
+        case .pumpBattery:
+            soundFile = .machineCharge
+            threshold = 20
         case .battery:
             soundFile = .machineCharge
             threshold = 20
@@ -363,7 +366,7 @@ extension AlarmType {
             return .glucose
         case .iob, .cob, .missedBolus, .recBolus:
             return .insulin
-        case .battery, .batteryDrop, .pump, .pumpChange,
+        case .battery, .batteryDrop, .pump, .pumpBattery, .pumpChange,
              .sensorChange, .notLooping, .buildExpire:
             return .device
         case .overrideStart, .overrideEnd, .tempTargetStart, .tempTargetEnd:
@@ -385,6 +388,7 @@ extension AlarmType {
         case .battery: return "battery.25"
         case .batteryDrop: return "battery.100.bolt"
         case .pump: return "drop"
+        case .pumpBattery: return "battery.25"
         case .pumpChange: return "arrow.triangle.2.circlepath"
         case .sensorChange: return "sensor.tag.radiowaves.forward"
         case .notLooping: return "circle.slash"
@@ -411,6 +415,7 @@ extension AlarmType {
         case .battery: return "Phone battery low."
         case .batteryDrop: return "Battery drops quickly."
         case .pump: return "Reservoir level low."
+        case .pumpBattery: return "Pump battery low."
         case .pumpChange: return "Pump change due."
         case .sensorChange: return "Sensor change due."
         case .notLooping: return "Loop hasn’t completed."

--- a/LoopFollow/Alarm/AlarmCondition/PumpBatteryCondition.swift
+++ b/LoopFollow/Alarm/AlarmCondition/PumpBatteryCondition.swift
@@ -1,0 +1,16 @@
+// LoopFollow
+// PumpBatteryCondition.swift
+
+import Foundation
+
+struct PumpBatteryCondition: AlarmCondition {
+    static let type: AlarmType = .pumpBattery
+    init() {}
+
+    func evaluate(alarm: Alarm, data: AlarmData, now _: Date) -> Bool {
+        guard let limit = alarm.threshold, limit > 0 else { return false }
+        guard let level = data.latestPumpBattery else { return false }
+
+        return level <= limit
+    }
+}

--- a/LoopFollow/Alarm/AlarmData.swift
+++ b/LoopFollow/Alarm/AlarmData.swift
@@ -20,6 +20,7 @@ struct AlarmData: Codable {
     let IOB: Double?
     let recentBoluses: [BolusEntry]
     let latestBattery: Double?
+    let latestPumpBattery: Double?
     let batteryHistory: [DataStructs.batteryStruct]
     let recentCarbs: [CarbSample]
 }

--- a/LoopFollow/Alarm/AlarmEditing/AlarmEditor.swift
+++ b/LoopFollow/Alarm/AlarmEditing/AlarmEditor.swift
@@ -77,6 +77,7 @@ struct AlarmEditor: View {
         case .sensorChange: SensorAgeAlarmEditor(alarm: $alarm)
         case .pumpChange: PumpChangeAlarmEditor(alarm: $alarm)
         case .pump: PumpVolumeAlarmEditor(alarm: $alarm)
+        case .pumpBattery: BatteryAlarmEditor(alarm: $alarm)
         case .iob: IOBAlarmEditor(alarm: $alarm)
         case .battery: BatteryAlarmEditor(alarm: $alarm)
         case .batteryDrop: BatteryDropAlarmEditor(alarm: $alarm)

--- a/LoopFollow/Alarm/AlarmManager.swift
+++ b/LoopFollow/Alarm/AlarmManager.swift
@@ -29,6 +29,7 @@ class AlarmManager {
             SensorAgeCondition.self,
             PumpChangeCondition.self,
             PumpVolumeCondition.self,
+            PumpBatteryCondition.self,
             IOBCondition.self,
             BatteryCondition.self,
             BatteryDropCondition.self,

--- a/LoopFollow/Alarm/AlarmType/AlarmType+Snooze.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType+Snooze.swift
@@ -16,7 +16,7 @@ extension AlarmType {
              .tempTargetEnd:
             return .minute
         case .battery, .batteryDrop, .sensorChange, .pumpChange, .cob, .iob,
-             .pump:
+             .pump, .pumpBattery:
             return .hour
         case .temporary:
             return .none

--- a/LoopFollow/Alarm/AlarmType/AlarmType+canAcknowledge.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType+canAcknowledge.swift
@@ -12,7 +12,7 @@ extension AlarmType {
             return true
         // These are alarms without memory, if they only are acknowledged - they would alarm again immediately
         case
-            .batteryDrop, .missedReading, .notLooping, .battery, .buildExpire, .iob, .sensorChange, .pumpChange, .pump:
+            .batteryDrop, .missedReading, .notLooping, .battery, .pumpBattery, .buildExpire, .iob, .sensorChange, .pumpChange, .pump:
             return false
         }
     }

--- a/LoopFollow/Alarm/AlarmType/AlarmType.swift
+++ b/LoopFollow/Alarm/AlarmType/AlarmType.swift
@@ -19,6 +19,7 @@ enum AlarmType: String, CaseIterable, Codable {
     case sensorChange = "Sensor Change Alert"
     case pumpChange = "Pump Change Alert"
     case pump = "Pump Insulin Alert"
+    case pumpBattery = "Pump Battery Alert"
     case battery = "Low Battery"
     case batteryDrop = "Battery Drop"
     case recBolus = "Rec. Bolus"

--- a/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
+++ b/LoopFollow/Controllers/Nightscout/DeviceStatus.swift
@@ -74,7 +74,7 @@ extension MainViewController {
 
     // NS Device Status Response Processor
     func updateDeviceStatusDisplay(jsonDeviceStatus: [[String: AnyObject]]) {
-        infoManager.clearInfoData(types: [.iob, .cob, .battery, .pump, .target, .isf, .carbRatio, .updated, .recBolus, .tdd])
+        infoManager.clearInfoData(types: [.iob, .cob, .battery, .pump, .pumpBattery, .target, .isf, .carbRatio, .updated, .recBolus, .tdd])
 
         // For Loop, clear the current override here - For Trio, it is handled using treatments
         if Storage.shared.device.value == "Loop" {
@@ -125,6 +125,14 @@ extension MainViewController {
                     latestPumpVolume = 50.0
                     infoManager.updateInfoData(type: .pump, value: "50+U")
                 }
+            }
+
+            // Parse pump battery percentage
+            if let pumpBatteryRecord = lastPumpRecord["battery"] as? [String: AnyObject],
+               let pumpBatteryPercent = pumpBatteryRecord["percent"] as? Double
+            {
+                infoManager.updateInfoData(type: .pumpBattery, value: String(format: "%.0f", pumpBatteryPercent) + "%")
+                Observable.shared.pumpBatteryLevel.value = pumpBatteryPercent
             }
 
             if let uploader = lastDeviceStatus?["uploader"] as? [String: AnyObject],

--- a/LoopFollow/InfoTable/InfoType.swift
+++ b/LoopFollow/InfoTable/InfoType.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 enum InfoType: Int, CaseIterable {
-    case iob, cob, basal, override, battery, pump, sage, cage, recBolus, minMax, carbsToday, autosens, profile, target, isf, carbRatio, updated, tdd, iage
+    case iob, cob, basal, override, battery, pump, pumpBattery, sage, cage, recBolus, minMax, carbsToday, autosens, profile, target, isf, carbRatio, updated, tdd, iage
 
     var name: String {
         switch self {
@@ -14,6 +14,7 @@ enum InfoType: Int, CaseIterable {
         case .override: return "Override"
         case .battery: return "Battery"
         case .pump: return "Pump"
+        case .pumpBattery: return "Pump Battery"
         case .sage: return "SAGE"
         case .cage: return "CAGE"
         case .recBolus: return "Rec. Bolus"

--- a/LoopFollow/Settings/ImportExport/AlarmSelectionView.swift
+++ b/LoopFollow/Settings/ImportExport/AlarmSelectionView.swift
@@ -219,6 +219,8 @@ struct AlarmSelectionRow: View {
             return "Pump Change Alert"
         case .pump:
             return "Pump Insulin Alert"
+        case .pumpBattery:
+            return "Pump Battery Alert"
         case .battery:
             return "Low Battery"
         case .batteryDrop:

--- a/LoopFollow/Storage/Observable.swift
+++ b/LoopFollow/Storage/Observable.swift
@@ -34,6 +34,7 @@ class Observable {
     var previousAlertLastLoopTime = ObservableValue<TimeInterval?>(default: nil)
     var deviceRecBolus = ObservableValue<Double?>(default: nil)
     var deviceBatteryLevel = ObservableValue<Double?>(default: nil)
+    var pumpBatteryLevel = ObservableValue<Double?>(default: nil)
     var enactedOrSuggested = ObservableValue<TimeInterval?>(default: nil)
 
     var settingsPath = ObservableValue<NavigationPath>(default: NavigationPath())

--- a/LoopFollow/Task/AlarmTask.swift
+++ b/LoopFollow/Task/AlarmTask.swift
@@ -26,6 +26,7 @@ extension MainViewController {
             let latestPumpVol = self.latestPumpVolume
             let bolusEntries = self.bolusData.map { BolusEntry(units: $0.value, date: Date(timeIntervalSince1970: $0.date)) }
             let latestBattery = Observable.shared.deviceBatteryLevel.value
+            let latestPumpBattery = Observable.shared.pumpBatteryLevel.value
             let recentCarbs: [CarbSample] = self.carbData.map { CarbSample(grams: $0.value, date: Date(timeIntervalSince1970: $0.date)) }
 
             let alarmData = AlarmData(
@@ -49,6 +50,7 @@ extension MainViewController {
                 IOB: self.latestIOB?.value,
                 recentBoluses: bolusEntries,
                 latestBattery: latestBattery,
+                latestPumpBattery: latestPumpBattery,
                 batteryHistory: self.deviceBatteryData,
                 recentCarbs: recentCarbs
             )


### PR DESCRIPTION
commit 0d8ae6951a053007c84eccd7e0e68a39fea14fb8
Author: Claude <noreply@anthropic.com>
Date:   Fri Jan 2 19:59:18 2026 +0000

    Add pumpBattery case to AlarmSelectionView switch

commit b67fb8bc98a7ecb0e4f54e889e8a5b8405c6f07a
Author: Claude <noreply@anthropic.com>
Date:   Fri Jan 2 19:55:21 2026 +0000

    Add pumpBattery case to AlarmEditor switch statement

    Reuses BatteryAlarmEditor for pump battery alarm configuration
    since both use threshold-based percentage settings.

commit 89cc3dad5820b0cb7ac18439f41c1968d4ba1414
Author: Claude <noreply@anthropic.com>
Date:   Fri Jan 2 19:46:56 2026 +0000

    Add pump battery display and alarm feature

    - Add pumpBattery to InfoType enum for Information Display table
    - Parse pump battery percentage from Nightscout API (pump.battery.percent)
    - Add pumpBatteryLevel observable for alarm data
    - Add pumpBattery alarm type with threshold-based triggering
    - Create PumpBatteryCondition for alarm evaluation
    - Register pump battery alarm in AlarmManager